### PR TITLE
Do not force renewal, only renew near expiry

### DIFF
--- a/getcert.sh
+++ b/getcert.sh
@@ -13,7 +13,7 @@ echo "Using server ${AUTHSERVER}"
 
 if [ -n "${RENEW}" ]; then
 	echo "Renewing."
-	certbot renew --force-renewal
+	certbot renew
 else
 	echo "Getting new cert."
 	if [ -z "${DOMAIN}" ]; then echo "Domain mising."; exit; fi


### PR DESCRIPTION
Currently scripts forces renewal always. This is a problem if the renewal attempt is scheduled twice a day as recommended by Let's Encrypt.

Patch removes the force flag so that it renews gently.

In some situations a force could be required, but a FORCE_RENEW=1 flag will be better for that (not implemented in this PR)